### PR TITLE
Remove hot bar from welcome page and add skybox to Tarot Experience

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,15 +31,27 @@ function LandingPage() {
 function App() {
   return (
     <Router>
-      <div className="app-container">
-        <HotBar />
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/tarot" element={<TarotExperience />} />
-          <Route path="/about" element={<div>About Page</div>} />
-          <Route path="/contact" element={<div>Contact Page</div>} />
-        </Routes>
-      </div>
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/tarot" element={
+          <>
+            <HotBar />
+            <TarotExperience />
+          </>
+        } />
+        <Route path="/about" element={
+          <>
+            <HotBar />
+            <div>About Page</div>
+          </>
+        } />
+        <Route path="/contact" element={
+          <>
+            <HotBar />
+            <div>Contact Page</div>
+          </>
+        } />
+      </Routes>
     </Router>
   )
 }

--- a/src/TarotExperience.tsx
+++ b/src/TarotExperience.tsx
@@ -21,10 +21,29 @@ const TarotExperience: React.FC = () => {
     const cube = new THREE.Mesh(geometry, material);
     scene.add(cube);
 
+    // Add skybox
+    const skyboxGeometry = new THREE.BoxGeometry(1000, 1000, 1000);
+    const skyboxMaterials = [
+      new THREE.MeshBasicMaterial({ map: new THREE.TextureLoader().load('/skybox/right.png'), side: THREE.BackSide }),
+      new THREE.MeshBasicMaterial({ map: new THREE.TextureLoader().load('/skybox/left.png'), side: THREE.BackSide }),
+      new THREE.MeshBasicMaterial({ map: new THREE.TextureLoader().load('/skybox/top.png'), side: THREE.BackSide }),
+      new THREE.MeshBasicMaterial({ map: new THREE.TextureLoader().load('/skybox/bottom.png'), side: THREE.BackSide }),
+      new THREE.MeshBasicMaterial({ map: new THREE.TextureLoader().load('/skybox/front.png'), side: THREE.BackSide }),
+      new THREE.MeshBasicMaterial({ map: new THREE.TextureLoader().load('/skybox/back.png'), side: THREE.BackSide }),
+    ];
+    const skybox = new THREE.Mesh(skyboxGeometry, skyboxMaterials);
+    scene.add(skybox);
+
     camera.position.z = 5;
 
     // Render the scene
-    renderer.render(scene, camera);
+    const animate = () => {
+      requestAnimationFrame(animate);
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+    };
+    animate();
 
     // Handle window resize
     const handleResize = () => {
@@ -35,7 +54,6 @@ const TarotExperience: React.FC = () => {
       camera.updateProjectionMatrix();
 
       renderer.setSize(width, height);
-      renderer.render(scene, camera);
     };
 
     window.addEventListener('resize', handleResize);


### PR DESCRIPTION
This pull request makes the following changes:

1. Removes the hot bar from the welcome page
2. Adds a skybox to the Tarot Experience

Changes in detail:
- Updated App.tsx to remove the hot bar from the LandingPage component
- Modified the routing in App.tsx to include the HotBar component only on specific routes
- Updated TarotExperience.tsx to add a skybox using six images for each side of the cube
- Re-enabled cube rotation in TarotExperience.tsx for a more dynamic scene

Note: This PR assumes that skybox images (right.png, left.png, top.png, bottom.png, front.png, back.png) are available in the '/skybox/' directory. These images need to be added to the project for the skybox to work correctly.