### PR TITLE
Add sphere position saving and prepare for card animation in TarotExperience

### DIFF
--- a/src/TarotExperience.tsx
+++ b/src/TarotExperience.tsx
@@ -2,9 +2,17 @@ import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 
+interface Position {
+  x: number;
+  y: number;
+  z: number;
+}
+
 const TarotExperience: React.FC<{ selectedSpread: string }> = ({ selectedSpread }) => {
   const mountRef = useRef<HTMLDivElement>(null);
   const [selectedObject, setSelectedObject] = useState<THREE.Mesh | null>(null);
+  const [spherePositions, setSpherePositions] = useState<Position[]>([]);
+  const spheresRef = useRef<THREE.Mesh[]>([]);
 
   useEffect(() => {
     if (!mountRef.current) return;
@@ -22,12 +30,6 @@ const TarotExperience: React.FC<{ selectedSpread: string }> = ({ selectedSpread 
     controls.enableDamping = true;
     controls.dampingFactor = 0.25;
     controls.enableZoom = true;
-
-    // Create a simple cube as a placeholder for the tarot card
-    const geometry = new THREE.BoxGeometry(1, 1.5, 0.1);
-    const material = new THREE.MeshBasicMaterial({ color: 0xffff00 }); // Changed to yellow
-    const cube = new THREE.Mesh(geometry, material);
-    scene.add(cube);
 
     // Create blue spheres for the selected tarot spread
     const sphereGeometry = new THREE.SphereGeometry(0.1, 32, 32);
@@ -68,10 +70,11 @@ const TarotExperience: React.FC<{ selectedSpread: string }> = ({ selectedSpread 
     const addSpheres = (spread: string) => {
       const spreadPositions = positions[spread];
       if (spreadPositions) {
-        spreadPositions.forEach(pos => {
+        spheresRef.current = spreadPositions.map(pos => {
           const sphere = new THREE.Mesh(sphereGeometry, sphereMaterial);
           sphere.position.set(pos.x, pos.y, pos.z);
           scene.add(sphere);
+          return sphere;
         });
       }
     };
@@ -175,15 +178,33 @@ const TarotExperience: React.FC<{ selectedSpread: string }> = ({ selectedSpread 
     };
   }, [selectedSpread]);
 
+  const saveSpherePositions = () => {
+    const positions = spheresRef.current.map(sphere => ({
+      x: sphere.position.x,
+      y: sphere.position.y,
+      z: sphere.position.z
+    }));
+    setSpherePositions(positions);
+    console.log('Saved sphere positions:', positions);
+  };
+
+  const animateCards = () => {
+    // Placeholder function for card animation
+    console.log('Animating cards to positions:', spherePositions);
+    // Implement card animation logic here
+  };
+
   return (
     <div style={{ position: 'relative', width: '100%', height: 'calc(100vh - 60px)', marginTop: '60px', display: 'flex', justifyContent: 'flex-start' }}>
       <div ref={mountRef} style={{ width: '80%', height: '100%' }} />
       <div style={{ width: '20%', padding: '20px' }}>
         <h3>Controls:</h3>
-        <p>Click on an object to select it.</p>
-        <p>Use arrow keys to move the selected object left, right, up, and down.</p>
-        <p>Use Page Up and Page Down to move the selected object forward and backward.</p>
+        <p>Click on a blue sphere to select it.</p>
+        <p>Use arrow keys to move the selected sphere left, right, up, and down.</p>
+        <p>Use Page Up and Page Down to move the selected sphere forward and backward.</p>
         <p>Use mouse to look around and zoom.</p>
+        <button onClick={saveSpherePositions}>Save Sphere Positions</button>
+        <button onClick={animateCards}>Animate Cards</button>
       </div>
     </div>
   );


### PR DESCRIPTION
This pull request adds functionality to save the positions of blue spheres in the TarotExperience component and prepares for future card animation:

1. Added a `Position` interface to define the structure of sphere positions.
2. Created a `spherePositions` state to store the positions of the blue spheres.
3. Added a `spheresRef` to keep track of the sphere meshes.
4. Modified the `addSpheres` function to store the created spheres in `spheresRef`.
5. Implemented a `saveSpherePositions` function to save the current positions of the spheres.
6. Added a placeholder `animateCards` function for future card animation implementation.
7. Updated the UI to include buttons for saving sphere positions and animating cards.

These changes allow users to customize the positions of the blue spheres representing tarot card positions and prepare the groundwork for animating tarot cards to these positions in the future.